### PR TITLE
[BACKLOG-560]   POJO instatiation was using the current class loader (vi...

### DIFF
--- a/src/org/pentaho/metastore/persist/MetaStoreFactory.java
+++ b/src/org/pentaho/metastore/persist/MetaStoreFactory.java
@@ -189,7 +189,7 @@ public class MetaStoreFactory<T> {
       Class<?> pojoClass;
       Object pojoObject;
       if ( objectFactory == null ) {
-        pojoClass = Class.forName( pojoChildClassName );
+        pojoClass = clazz.getClassLoader().loadClass( pojoChildClassName );
         pojoObject = pojoClass.newInstance();
       } else {
         Map<String, String> objectFactoryContext = getObjectFactoryContext( child );


### PR DESCRIPTION
...a Class.forName), which may not be correct if the instantiated class is part of a plugin.

@mattcasters @deinspanjer 
