### PR TITLE
[PDI-13408] - Without memory sensitive cache

### DIFF
--- a/src/org/pentaho/metastore/stores/xml/SimpleXmlMetaStoreCache.java
+++ b/src/org/pentaho/metastore/stores/xml/SimpleXmlMetaStoreCache.java
@@ -1,0 +1,177 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.metastore.stores.xml;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.pentaho.metastore.api.IMetaStoreElementType;
+
+/**
+ * This implementation provides a simple XmlMetaStoreCache.
+ * It uses hard links and client should clear it manually.
+ *
+ */
+public class SimpleXmlMetaStoreCache implements XmlMetaStoreCache {
+
+  private final Map<String, Long> processedFiles = new HashMap<String, Long>();
+  
+  private final Map<String, Map<String, ElementType>> elementTypesMap = new HashMap<String, Map<String, ElementType>>();
+  
+  @Override
+  public synchronized void registerElementTypeIdForName( String namespace, String elementTypeName, String elementId ) {
+    Map<String, ElementType> elementTypeNameToId = elementTypesMap.get( namespace );
+    if (elementTypeNameToId == null) {
+      elementTypeNameToId = new HashMap<String, ElementType>();
+      elementTypesMap.put( namespace, elementTypeNameToId );
+    }
+    ElementType elementType = elementTypeNameToId.get( elementTypeName );
+    if (elementType == null) {
+      elementType = new ElementType( elementId );
+      elementTypeNameToId.put( elementTypeName, elementType );
+    } else if (!elementType.getId().equals( elementId )) {
+      elementType.unregisterElements();
+      elementType.setId( elementId );
+    }
+  }
+
+  @Override
+  public synchronized String getElementTypeIdByName( String namespace, String elementTypeName ) {
+    Map<String, ElementType> elementTypeNameToId = elementTypesMap.get( namespace );
+    if ( elementTypeNameToId == null) {
+      return null;
+    }
+    
+    ElementType element = elementTypeNameToId.get( elementTypeName );
+    return element == null ? null : element.getId();
+  }
+
+  @Override
+  public synchronized void unregisterElementTypeId( String namespace, String elementTypeId ) {
+    Map<String, ElementType> elementTypeNameToId = elementTypesMap.get( namespace );
+    if (elementTypeNameToId == null) {
+      return;
+    }
+    Iterator<Entry<String, ElementType>> iterator = elementTypeNameToId.entrySet().iterator();
+    while ( iterator.hasNext() ) {
+      Entry<String, ElementType> elementType = iterator.next();
+      if (elementType.getValue().getId().equals( elementTypeId )) {
+        iterator.remove();
+        return;
+      }
+    }
+  }
+
+  @Override
+  public synchronized void registerElementIdForName( String namespace, IMetaStoreElementType elementType, String elementName,
+      String elementId ) {
+    Map<String, ElementType> nameToElementType = elementTypesMap.get( namespace );
+    if (nameToElementType == null) {
+      registerElementTypeIdForName( namespace, elementType.getName(), elementType.getId() );
+      nameToElementType = elementTypesMap.get( namespace );
+    }
+    ElementType type = nameToElementType.get( elementType.getName() );
+    if (type != null) {
+      type.registerElementIdForName( elementName, elementId );
+    }
+  }
+
+  @Override
+  public synchronized String getElementIdByName( String namespace, IMetaStoreElementType elementType, String elementName ) {
+    Map<String, ElementType> elementTypeNameToId = elementTypesMap.get( namespace );
+    if ( elementTypeNameToId == null) {
+      return null;
+    }
+    ElementType type = elementTypeNameToId.get( elementType.getName() );
+    return type == null ? null : type.getElementIdByName( elementName );
+  }
+
+  @Override
+  public synchronized void unregisterElementId( String namespace, IMetaStoreElementType elementType, String elementId ) {
+    Map<String, ElementType> elementTypeNameToId = elementTypesMap.get( namespace );
+    if ( elementTypeNameToId == null) {
+      return;
+    }
+    ElementType type = elementTypeNameToId.get( elementType.getName() );
+    if (type == null) {
+      return;
+    }
+    type.unregisterElementId( elementId );
+  }
+
+  @Override
+  public synchronized void registerProcessedFile( String fullPath, long lastUpdate ) {
+    processedFiles.put( fullPath, lastUpdate );
+  }
+
+  @Override
+  public synchronized Map<String, Long> getProcessedFiles() {
+    return Collections.unmodifiableMap( processedFiles );
+  }
+
+  @Override
+  public synchronized void unregisterProcessedFile( String fullPath ) {
+    processedFiles.remove( fullPath );
+  }
+
+  private static class ElementType {
+    
+    private final Map<String, String> elementNameToIdMap = new HashMap<String, String>();
+    
+    private String id;
+    
+    public ElementType(String id) {
+      this.id = id;
+    }
+    
+    public String getId() {
+      return id;
+    }
+
+    public void setId( String id ) {
+      this.id = id;
+    }
+
+    public void registerElementIdForName( String elementName, String elementId ) {
+      elementNameToIdMap.put( elementName, elementId );
+    }
+
+    public String getElementIdByName( String elementName ) {
+      return elementNameToIdMap.get( elementName );
+    }
+
+    public void unregisterElementId( String elementId ) {
+      Iterator<Entry<String, String>> iterator = elementNameToIdMap.entrySet().iterator();
+      while ( iterator.hasNext() ) {
+        Entry<String, String> element = iterator.next();
+        if (element.getValue().equals( elementId )) {
+          iterator.remove();
+          return;
+        }
+      }
+    }
+    
+    public void unregisterElements() {
+      elementNameToIdMap.clear();
+    }
+    
+  }
+  
+}

--- a/src/org/pentaho/metastore/stores/xml/XmlMetaStore.java
+++ b/src/org/pentaho/metastore/stores/xml/XmlMetaStore.java
@@ -22,6 +22,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.pentaho.metastore.api.BaseMetaStore;
@@ -42,12 +43,22 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
   private String rootFolder;
 
   private File rootFile;
+  
+  private final XmlMetaStoreCache metaStoreCache;
 
   public XmlMetaStore() throws MetaStoreException {
-    this( System.getProperty( "java.io.tmpdir" ) + File.separator + UUID.randomUUID() );
+    this( XmlMetaStoreCache.NO_CACHE_INSTANCE );
+  }
+  
+  public XmlMetaStore( XmlMetaStoreCache metaStoreCacheImpl ) throws MetaStoreException {
+    this( System.getProperty( "java.io.tmpdir" ) + File.separator + UUID.randomUUID(), metaStoreCacheImpl );
+  }
+  
+  public XmlMetaStore( String rootFolder ) throws MetaStoreException {
+    this( rootFolder, XmlMetaStoreCache.NO_CACHE_INSTANCE );
   }
 
-  public XmlMetaStore( String rootFolder ) throws MetaStoreException {
+  public XmlMetaStore( String rootFolder, XmlMetaStoreCache metaStoreCacheImpl ) throws MetaStoreException {
     this.rootFolder = rootFolder + File.separator + XmlUtil.META_FOLDER_NAME;
 
     rootFile = new File( this.rootFolder );
@@ -60,6 +71,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
     // Give the MetaStore a default name
     //
     setName( this.rootFolder );
+    metaStoreCache = metaStoreCacheImpl;
   }
 
   @Override
@@ -78,7 +90,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
     lockStore();
     try {
       File[] files = listFolders( rootFile );
-      List<String> namespaces = new ArrayList<String>();
+      List<String> namespaces = new ArrayList<String>( files.length );
       for ( File file : files ) {
         namespaces.add( file.getName() );
       }
@@ -131,7 +143,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       List<IMetaStoreElementType> elementTypes = getElementTypes( namespace, false );
 
       if ( !elementTypes.isEmpty() ) {
-        List<String> dependencies = new ArrayList<String>();
+        List<String> dependencies = new ArrayList<String>( elementTypes.size() );
         for ( IMetaStoreElementType elementType : elementTypes ) {
           dependencies.add( elementType.getId() );
         }
@@ -159,11 +171,10 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       lockStore();
     }
     try {
-      List<IMetaStoreElementType> elementTypes = new ArrayList<IMetaStoreElementType>();
-
       String spaceFolder = XmlUtil.getNamespaceFolder( rootFolder, namespace );
       File spaceFolderFile = new File( spaceFolder );
       File[] elementTypeFolders = listFolders( spaceFolderFile );
+      List<IMetaStoreElementType> elementTypes = new ArrayList<IMetaStoreElementType>( elementTypeFolders.length );
       for ( File elementTypeFolder : elementTypeFolders ) {
         String elementTypeId = elementTypeFolder.getName();
         IMetaStoreElementType elementType = getElementType( namespace, elementTypeId, false );
@@ -182,11 +193,10 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
   public synchronized List<String> getElementTypeIds( String namespace ) throws MetaStoreException {
     lockStore();
     try {
-      List<String> ids = new ArrayList<String>();
-
       String spaceFolder = XmlUtil.getNamespaceFolder( rootFolder, namespace );
       File spaceFolderFile = new File( spaceFolder );
       File[] elementTypeFolders = listFolders( spaceFolderFile );
+      List<String> ids = new ArrayList<String>( elementTypeFolders.length );
       for ( File elementTypeFolder : elementTypeFolders ) {
         String elementTypeId = elementTypeFolder.getName();
         ids.add( elementTypeId );
@@ -265,6 +275,10 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
               .getDescription() );
       xmlType.setFilename( elementTypeFilename );
       xmlType.save();
+      
+      metaStoreCache.registerElementTypeIdForName( namespace, elementType.getName(), elementType.getId() );
+      metaStoreCache.registerProcessedFile( elementTypeFolder, new File( elementTypeFolder ).lastModified() );
+      
       xmlType.setMetaStoreName( getName() );
       elementType.setMetaStoreName( getName() );
     } finally {
@@ -293,6 +307,9 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
               .getDescription() );
       xmlType.setFilename( elementTypeFilename );
       xmlType.save();
+      
+      metaStoreCache.registerElementTypeIdForName( namespace, elementType.getName(), elementType.getId() );
+      metaStoreCache.registerProcessedFile( elementTypeFolder, elementTypeFolderFile.lastModified() );
     } finally {
       unlockStore();
     }
@@ -309,7 +326,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
         return;
       }
       // Check if the element type has no remaining elements
-      List<IMetaStoreElement> elements = getElements( namespace, elementType, false );
+      List<IMetaStoreElement> elements = getElements( namespace, elementType, false, true );
       if ( !elements.isEmpty() ) {
         List<String> dependencies = new ArrayList<String>();
         for ( IMetaStoreElement element : elements ) {
@@ -332,6 +349,8 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       if ( !elementTypeFolderFile.delete() ) {
         throw new MetaStoreException( "Unable to delete element type XML folder '" + elementTypeFolder + "'" );
       }
+      metaStoreCache.unregisterElementTypeId( namespace, elementType.getId() );
+      metaStoreCache.unregisterProcessedFile( elementTypeFolder );
     } finally {
       unlockStore();
     }
@@ -340,20 +359,19 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
   @Override
   public List<IMetaStoreElement> getElements( String namespace, IMetaStoreElementType elementType )
     throws MetaStoreException {
-    return getElements( namespace, elementType, true );
+    return getElements( namespace, elementType, true, true );
   }
 
   protected synchronized List<IMetaStoreElement> getElements( String namespace, IMetaStoreElementType elementType,
-      boolean lock ) throws MetaStoreException {
+      boolean lock, boolean includeProcessedFiles ) throws MetaStoreException {
     if ( lock ) {
       lockStore();
     }
     try {
-      List<IMetaStoreElement> elements = new ArrayList<IMetaStoreElement>();
-
       String elementTypeFolder = XmlUtil.getElementTypeFolder( rootFolder, namespace, elementType.getName() );
       File elementTypeFolderFile = new File( elementTypeFolder );
-      File[] elementTypeFiles = listFiles( elementTypeFolderFile );
+      File[] elementTypeFiles = listFiles( elementTypeFolderFile, includeProcessedFiles );
+      List<IMetaStoreElement> elements = new ArrayList<IMetaStoreElement>( elementTypeFiles.length );
       for ( File elementTypeFile : elementTypeFiles ) {
         String elementId = elementTypeFile.getName();
         // File .type.xml doesn't hidden in OS Windows so better to ignore it explicitly
@@ -377,11 +395,10 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
     throws MetaStoreException {
     lockStore();
     try {
-      List<String> elementIds = new ArrayList<String>();
-
       String elementTypeFolder = XmlUtil.getElementTypeFolder( rootFolder, namespace, elementType.getName() );
       File elementTypeFolderFile = new File( elementTypeFolder );
-      File[] elementTypeFiles = listFiles( elementTypeFolderFile );
+      File[] elementTypeFiles = listFiles( elementTypeFolderFile, true );
+      List<String> elementIds = new ArrayList<String>( elementTypeFiles.length );
       for ( File elementTypeFile : elementTypeFiles ) {
         String elementId = elementTypeFile.getName();
         // File .type.xml doesn't hidden in OS Windows so better to ignore it explicitly
@@ -415,7 +432,10 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       if ( !elementFile.exists() ) {
         return null;
       }
-      return new XmlMetaStoreElement( elementFilename );
+      XmlMetaStoreElement element = new XmlMetaStoreElement( elementFilename );
+      metaStoreCache.registerElementIdForName( namespace, elementType, element.getName(), elementId );
+      metaStoreCache.registerProcessedFile( elementFilename, elementFile.lastModified() );
+      return element;
     } finally {
       if ( lock ) {
         unlockStore();
@@ -424,14 +444,27 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
   }
 
   @Override
-  public IMetaStoreElement getElementByName( String namespace, IMetaStoreElementType elementType, String name )
+  public synchronized IMetaStoreElement getElementByName( String namespace, IMetaStoreElementType elementType, String name )
     throws MetaStoreException {
-    for ( IMetaStoreElement element : getElements( namespace, elementType ) ) {
-      if ( element.getName() != null && element.getName().equalsIgnoreCase( name ) ) {
-        return element;
+    lockStore();
+    try {
+      String chachedElementId = metaStoreCache.getElementIdByName( namespace, elementType, name );
+      if ( chachedElementId != null ) {
+        IMetaStoreElement element = getElement( namespace, elementType, chachedElementId, false );
+        if ( element != null && element.getName().equalsIgnoreCase( name ) ) {
+          return element;
+        }
       }
+
+      for ( IMetaStoreElement element : getElements( namespace, elementType, false, false ) ) {
+        if ( element.getName() != null && element.getName().equalsIgnoreCase( name ) ) {
+          return element;
+        }
+      }
+      return null;
+    } finally {
+      unlockStore();
     }
-    return null;
   }
 
   public synchronized void
@@ -448,13 +481,15 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       String elementFilename = XmlUtil.getElementFile( rootFolder, namespace, elementType.getName(), element.getId() );
       File elementFile = new File( elementFilename );
       if ( elementFile.exists() ) {
-        throw new MetaStoreElementExistException( getElements( namespace, elementType, false ),
+        throw new MetaStoreElementExistException( getElements( namespace, elementType, false, true ),
             "The specified element already exists with the same ID: '" + element.getId() + "'" );
       }
       XmlMetaStoreElement xmlElement = new XmlMetaStoreElement( element );
       xmlElement.setFilename( elementFilename );
       xmlElement.save();
-
+      
+      metaStoreCache.registerElementIdForName( namespace, elementType, xmlElement.getName(), element.getId() );
+      metaStoreCache.registerProcessedFile( elementFilename , new File( elementFilename ).lastModified() );
       // In the case of the XML store, the name is the same as the ID
       //
       element.setId( xmlElement.getName() );
@@ -486,6 +521,9 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       xmlElement.setFilename( elementFilename );
       xmlElement.setIdWithFilename( elementFilename );
       xmlElement.save();
+      
+      metaStoreCache.registerElementIdForName( namespace, elementType, xmlElement.getName(), element.getId() );
+      metaStoreCache.registerProcessedFile( elementFilename, elementFile.lastModified() );
     } finally {
       unlockStore();
     }
@@ -506,6 +544,9 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
         throw new MetaStoreException( "Unable to delete element with ID '" + elementId + "' in filename '"
             + elementFilename + "'" );
       }
+      
+      metaStoreCache.unregisterElementId( namespace, elementType, elementId );
+      metaStoreCache.unregisterProcessedFile( elementFilename );
     } finally {
       unlockStore();
     }
@@ -545,12 +586,20 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
 
   /**
    * @param folder
+   * @param includeProcessedFiles
    * @return the non-hidden files in the specified folder
    */
-  protected File[] listFiles( File folder ) {
+  protected File[] listFiles( File folder, final boolean includeProcessedFiles ) {
     File[] files = folder.listFiles( new FileFilter() {
       @Override
       public boolean accept( File file ) {
+        if ( !includeProcessedFiles ) {
+          Map<String, Long> processedFiles = metaStoreCache.getProcessedFiles();
+          Long fileLastModified = processedFiles.get( file.getPath() );
+          if ( fileLastModified != null && fileLastModified.equals( file.lastModified() ) ) {
+            return false;
+          }
+        }
         return !file.isHidden() && file.isFile();
       }
     } );

--- a/src/org/pentaho/metastore/stores/xml/XmlMetaStoreCache.java
+++ b/src/org/pentaho/metastore/stores/xml/XmlMetaStoreCache.java
@@ -1,0 +1,145 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.metastore.stores.xml;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.pentaho.metastore.api.IMetaStoreElementType;
+
+/**
+ * This interface describes the cache object for XmlMetaStore.
+ *
+ */
+public interface XmlMetaStoreCache {
+  
+  /**
+   * 
+   * 
+   * @param namespace
+   * @param elementTypeName
+   * @param elementTypeId
+   */
+  void registerElementTypeIdForName( String namespace, String elementTypeName, String elementTypeId );
+  
+  /**
+   * 
+   * @param namespace
+   * @param elementTypeName
+   * @return
+   */
+  String getElementTypeIdByName( String namespace, String elementTypeName );
+  
+  /**
+   * 
+   * @param namespace
+   * @param elementTypeId
+   */
+  void unregisterElementTypeId( String namespace, String elementTypeId );
+  
+  /**
+   * 
+   * @param namespace
+   * @param elementType
+   * @param elementName
+   * @param elementId
+   */
+  void registerElementIdForName( String namespace, IMetaStoreElementType elementType, String elementName, String elementId );
+  
+  /**
+   * 
+   * @param namespace
+   * @param elementType
+   * @param elementName
+   * @return
+   */
+  String getElementIdByName( String namespace, IMetaStoreElementType elementType, String elementName );
+  
+  /**
+   * 
+   * @param namespace
+   * @param elementType
+   * @param elementId
+   */
+  void unregisterElementId( String namespace, IMetaStoreElementType elementType, String elementId );
+  
+  /**
+   * 
+   * @param fullPath
+   * @param lastModified
+   */
+  void registerProcessedFile( String fullPath, long lastModified );
+  
+  /**
+   * 
+   * @return
+   */
+  Map<String, Long> getProcessedFiles();
+  
+  /**
+   * 
+   * @param fullPath
+   */
+  void unregisterProcessedFile( String fullPath );
+  
+  /**
+   * Default non-caching implementation.
+   */
+  XmlMetaStoreCache NO_CACHE_INSTANCE = new XmlMetaStoreCache() {
+
+    @Override
+    public void registerElementTypeIdForName( String namespace, String elementTypeName, String elementTypeId ) {
+    }
+
+    @Override
+    public String getElementTypeIdByName( String namespace, String elementTypeName ) {
+      return null;
+    }
+
+    @Override
+    public void unregisterElementTypeId( String namespace, String elementTypeId ) {
+    }
+
+    @Override
+    public void registerElementIdForName( String namespace, IMetaStoreElementType elementType, String elementName, String elementId ) {
+    }
+
+    @Override
+    public String getElementIdByName( String namespace, IMetaStoreElementType elementType, String elementName ) {
+      return null;
+    }
+
+    @Override
+    public void unregisterElementId( String namespace, IMetaStoreElementType elementType, String elementId ) {
+    }
+
+    @Override
+    public void registerProcessedFile( String fullPath, long lastModified ) {
+    }
+
+    @Override
+    public Map<String, Long> getProcessedFiles() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public void unregisterProcessedFile( String fullPath ) {
+    }
+    
+  };
+  
+}

--- a/test-src/org/pentaho/metastore/stores/xml/SimpleXmlMetaStoreCacheTest.java
+++ b/test-src/org/pentaho/metastore/stores/xml/SimpleXmlMetaStoreCacheTest.java
@@ -1,0 +1,86 @@
+package org.pentaho.metastore.stores.xml;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+import org.pentaho.metastore.api.IMetaStoreElementType;
+
+public class SimpleXmlMetaStoreCacheTest {
+
+  private SimpleXmlMetaStoreCache simpleXmlMetaStoreCache;
+  
+  @Before
+  public void before() {
+    simpleXmlMetaStoreCache = new SimpleXmlMetaStoreCache();
+  }
+  
+  @Test
+  public void registerElementTypeIdForName() {
+    simpleXmlMetaStoreCache.registerElementTypeIdForName( "testNamespace", "testElementTypeName", "testElementTypeId" );
+    String actualElementId = simpleXmlMetaStoreCache.getElementTypeIdByName( "testNamespace", "testElementTypeName" );
+    assertEquals( "testElementTypeId", actualElementId );
+  }
+  
+  @Test
+  public void unregisterElementTypeIdForName() {
+    simpleXmlMetaStoreCache.registerElementTypeIdForName( "testNamespace", "testElementTypeName", "testElementTypeId" );
+    simpleXmlMetaStoreCache.unregisterElementTypeId( "testNamespace", "testElementTypeId" );
+    String actualElementId = simpleXmlMetaStoreCache.getElementTypeIdByName( "testNamespace", "testElementTypeName" );
+    assertNull( actualElementId );
+  }
+  
+  @Test
+  public void registerElementIdForName() {
+    IMetaStoreElementType testElementType = createTestElementType( "testElementTypeName", "testElementTypeId" );
+    simpleXmlMetaStoreCache.registerElementTypeIdForName( "testNamespace", testElementType.getName(), testElementType.getId() );
+    simpleXmlMetaStoreCache.registerElementIdForName( "testNamespace", testElementType, "testElementName", "testElementId" );
+    String actualElementId = simpleXmlMetaStoreCache.getElementIdByName( "testNamespace", testElementType, "testElementName" );
+    assertEquals( "testElementId", actualElementId );
+  }
+  
+  @Test
+  public void registerElementIdForName_for_non_registered_type() {
+    IMetaStoreElementType testElementType = createTestElementType( "testElementTypeName", "testElementTypeId" );
+    simpleXmlMetaStoreCache.registerElementIdForName( "testNamespace", testElementType, "testElementName", "testElementId" );
+    String actualElementId = simpleXmlMetaStoreCache.getElementIdByName( "testNamespace", testElementType, "testElementName" );
+    assertEquals( "testElementId", actualElementId );
+  }
+  
+  @Test
+  public void unregisterElementIdForName() {
+    IMetaStoreElementType testElementType = createTestElementType( "testElementTypeName", "testElementTypeId" );
+    simpleXmlMetaStoreCache.registerElementTypeIdForName( "testNamespace", testElementType.getName(), testElementType.getId() );
+    simpleXmlMetaStoreCache.registerElementIdForName( "testNamespace", testElementType, "testElementName", "testElementId" );
+    simpleXmlMetaStoreCache.unregisterElementId( "testNamespace", testElementType, "testElementId" );
+    String actualElementId = simpleXmlMetaStoreCache.getElementIdByName( "testNamespace", testElementType, "testElementName" );
+    assertNull( "testElementId", actualElementId );
+  }
+  
+  @Test
+  public void registerProcessedFile() {
+    simpleXmlMetaStoreCache.registerProcessedFile( "/test/full/Path", 1L );
+    Map<String, Long> actualProcessedFiles = simpleXmlMetaStoreCache.getProcessedFiles();
+    assertThat( actualProcessedFiles.size(), equalTo( 1 ) );
+    assertThat( actualProcessedFiles.containsKey( "/test/full/Path" ), is( true ));
+  }
+  
+  @Test
+  public void unregisterProcessedFile() {
+    simpleXmlMetaStoreCache.registerProcessedFile( "/test/full/Path", 1L );
+    simpleXmlMetaStoreCache.unregisterProcessedFile( "/test/full/Path" );
+    Map<String, Long> actualProcessedFiles = simpleXmlMetaStoreCache.getProcessedFiles();
+    assertThat( actualProcessedFiles.size(), equalTo( 0 ) );
+  }
+  
+  private static IMetaStoreElementType createTestElementType( String typeName, String typeId ) {
+    IMetaStoreElementType testElementType = mock( IMetaStoreElementType.class );
+    when( testElementType.getName() ).thenReturn( typeName );
+    when( testElementType.getId() ).thenReturn( typeId );
+    return testElementType;
+  }
+}

--- a/test-src/org/pentaho/metastore/stores/xml/XmlMetaStoreWithSimpleCacheTest.java
+++ b/test-src/org/pentaho/metastore/stores/xml/XmlMetaStoreWithSimpleCacheTest.java
@@ -1,0 +1,29 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.metastore.stores.xml;
+
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.test.XmlMetaStoreTest;
+
+public class XmlMetaStoreWithSimpleCacheTest extends XmlMetaStoreTest {
+  
+  @Override
+  protected XmlMetaStore createMetaStore() throws MetaStoreException {
+    return new XmlMetaStore( new SimpleXmlMetaStoreCache() );
+  }
+  
+}

--- a/test-src/org/pentaho/metastore/test/XmlMetaStoreTest.java
+++ b/test-src/org/pentaho/metastore/test/XmlMetaStoreTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.stores.xml.XmlMetaStore;
 import org.pentaho.metastore.util.FileUtil;
 
@@ -32,7 +33,11 @@ public class XmlMetaStoreTest extends MetaStoreTestBase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    metaStore = new XmlMetaStore();
+    metaStore = createMetaStore();
+  }
+  
+  protected XmlMetaStore createMetaStore() throws MetaStoreException {
+    return new XmlMetaStore();
   }
 
   @Override


### PR DESCRIPTION
@mdamour1976  please review.
These changes include fixed XmlMetaStore which is able to work with cache (to improve perfomance of add/get operations).
By default XmlMetaStore will not use cache. The developer have to add reference on cache's implementation as constructor's argument in XmlMetaStore, to add cache for kettle's XmlMetastore and other projects.