### PR TITLE
[PDI-13408] - Added fix for caching in updateElement method. + XmlMetaStoreCache ignores elementId with null value.

### DIFF
--- a/src/org/pentaho/metastore/stores/xml/BaseXmlMetaStoreCache.java
+++ b/src/org/pentaho/metastore/stores/xml/BaseXmlMetaStoreCache.java
@@ -145,6 +145,9 @@ public abstract class BaseXmlMetaStoreCache implements XmlMetaStoreCache {
     protected abstract Map<String, String> getElementNameToIdMap();
 
     public void registerElementIdForName( String elementName, String elementId ) {
+      if ( elementId == null ) {
+        return;
+      }
       Map<String, String> elementNameToIdMap = getElementNameToIdMap();
       elementNameToIdMap.put( elementName, elementId );
     }

--- a/src/org/pentaho/metastore/stores/xml/XmlMetaStore.java
+++ b/src/org/pentaho/metastore/stores/xml/XmlMetaStore.java
@@ -522,7 +522,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
       xmlElement.setIdWithFilename( elementFilename );
       xmlElement.save();
       
-      metaStoreCache.registerElementIdForName( namespace, elementType, xmlElement.getName(), element.getId() );
+      metaStoreCache.registerElementIdForName( namespace, elementType, xmlElement.getName(), xmlElement.getId() );
       metaStoreCache.registerProcessedFile( elementFilename, elementFile.lastModified() );
     } finally {
       unlockStore();

--- a/src/org/pentaho/metastore/stores/xml/XmlMetaStoreCache.java
+++ b/src/org/pentaho/metastore/stores/xml/XmlMetaStoreCache.java
@@ -69,7 +69,7 @@ public interface XmlMetaStoreCache {
    * @param elementName
    *          the element's name
    * @param elementId
-   *          the element's id
+   *          the element's id. XmlMetaStoreCache doesn't register element's id with null value.
    */
   void registerElementIdForName( String namespace, IMetaStoreElementType elementType, String elementName, String elementId );
   

--- a/test-src/org/pentaho/metastore/stores/xml/XmlMetaStoreCacheTestBase.java
+++ b/test-src/org/pentaho/metastore/stores/xml/XmlMetaStoreCacheTestBase.java
@@ -69,6 +69,15 @@ public abstract class XmlMetaStoreCacheTestBase {
   }
   
   @Test
+  public void registerElementIdForName_for_null_id() {
+    IMetaStoreElementType testElementType = createTestElementType( "testElementTypeName", "testElementTypeId" );
+    simpleXmlMetaStoreCache.registerElementTypeIdForName( "testNamespace", testElementType.getName(), testElementType.getId() );
+    simpleXmlMetaStoreCache.registerElementIdForName( "testNamespace", testElementType, "testElementName", null );
+    String actualElementId = simpleXmlMetaStoreCache.getElementIdByName( "testNamespace", testElementType, "testElementName" );
+    assertNull( actualElementId );
+  }
+  
+  @Test
   public void registerElementIdForName_for_non_registered_type() {
     IMetaStoreElementType testElementType = createTestElementType( "testElementTypeName", "testElementTypeId" );
     simpleXmlMetaStoreCache.registerElementIdForName( "testNamespace", testElementType, "testElementName", "testElementId" );


### PR DESCRIPTION
@mdamour1976 please review.

I've changed updateElement method, now it registers elementId from xmlElement in cache. I've also changed cache, so now it ignores null elementId.