### PR TITLE
[TEST] Add unit tests on saving/loading child POJOs

### DIFF
--- a/test-res/metastore_test/metastore/pentaho/ParentElement/.type.xml
+++ b/test-res/metastore_test/metastore/pentaho/ParentElement/.type.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<data-type>
+  <name>ParentElement</name>
+  <description>ParentElement</description>
+</data-type>

--- a/test-res/metastore_test/metastore/pentaho/ParentElement/test.xml
+++ b/test-res/metastore_test/metastore/pentaho/ParentElement/test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<element>
+  <id>test</id>
+  <value/>
+  <type>String</type>
+  <children>
+    <child>
+      <id>childElement</id>
+      <value>org.pentaho.metastore.test.testclasses.my.ChildElement</value>
+      <type>String</type>
+      <children>
+        <child>
+          <id>property2</id>
+          <value>p2</value>
+          <type>String</type>
+        </child>
+        <child>
+          <id>property1</id>
+          <value>p1</value>
+          <type>String</type>
+        </child>
+      </children>
+    </child>
+    <child>
+      <id>name</id>
+      <value>test</value>
+      <type>String</type>
+    </child>
+  </children>
+  <name>test</name>
+  <security>
+    <owner/>
+    <owner-permissions-list/>
+  </security>
+</element>

--- a/test-src/org/pentaho/metastore/test/PojoChildTest.java
+++ b/test-src/org/pentaho/metastore/test/PojoChildTest.java
@@ -1,0 +1,81 @@
+package org.pentaho.metastore.test;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.persist.MetaStoreFactory;
+import org.pentaho.metastore.stores.xml.XmlMetaStore;
+import org.pentaho.metastore.test.testclasses.my.ChildElement;
+import org.pentaho.metastore.test.testclasses.my.ParentElement;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class PojoChildTest {
+
+  private String tempDir = null;
+  private IMetaStore metaStore = null;
+
+  private static String XML_METASTORE = "test-res/metastore_test";
+
+  @Before
+  public void before() throws IOException, MetaStoreException {
+    File f = File.createTempFile( "MultiLevelListTest", "before" );
+    f.deleteOnExit();
+
+    tempDir = f.getParent();
+    metaStore = new XmlMetaStore( tempDir );
+  }
+
+  @After
+  public void after() throws IOException {
+    FileUtils.deleteDirectory( new File( ( (XmlMetaStore) metaStore ).getRootFolder() ) );
+  }
+
+  public MetaStoreFactory<ParentElement> getMetaStoreFactory( IMetaStore metaStore ) {
+
+    MetaStoreFactory<ParentElement>
+      factory =
+      new MetaStoreFactory( ParentElement.class, metaStore, "pentaho" );
+    return factory;
+  }
+
+  @Test
+  public void testSaveAndLoad() throws Exception {
+    ParentElement p = createSample();
+    getMetaStoreFactory( this.metaStore ).saveElement( p );
+    ParentElement lp = getMetaStoreFactory( this.metaStore ).loadElement( "test" );
+    verify( p, lp );
+  }
+
+  @Test
+  public void testLoadFromFile() throws Exception {
+    ParentElement p = createSample();
+    XmlMetaStore xmlMetaStore = new XmlMetaStore( XML_METASTORE );
+    ParentElement lp = getMetaStoreFactory( xmlMetaStore ).loadElement( "test" );
+    verify( p, lp );
+  }
+
+  private ParentElement createSample() {
+    ChildElement c = new ChildElement();
+    c.setProperty1( "p1" );
+    c.setProperty2( "p2" );
+    ParentElement p = new ParentElement();
+    p.setName( "test" );
+    p.setChildElement( c );
+    return p;
+  }
+
+  private void verify( ParentElement original, ParentElement loaded ) {
+    assertNotNull( original );
+    assertNotNull( loaded );
+    assertEquals( original.getChildElement().getProperty1(), loaded.getChildElement().getProperty1() );
+    assertEquals( original.getChildElement().getProperty2(), loaded.getChildElement().getProperty2() );
+  }
+}

--- a/test-src/org/pentaho/metastore/test/testclasses/my/ChildElement.java
+++ b/test-src/org/pentaho/metastore/test/testclasses/my/ChildElement.java
@@ -1,0 +1,29 @@
+package org.pentaho.metastore.test.testclasses.my;
+
+
+import org.pentaho.metastore.persist.MetaStoreAttribute;
+
+public class ChildElement {
+
+  @MetaStoreAttribute
+  private String property1;
+
+  @MetaStoreAttribute
+  private String property2;
+
+  public String getProperty1() {
+    return property1;
+  }
+
+  public void setProperty1( String property1 ) {
+    this.property1 = property1;
+  }
+
+  public String getProperty2() {
+    return property2;
+  }
+
+  public void setProperty2( String property2 ) {
+    this.property2 = property2;
+  }
+}

--- a/test-src/org/pentaho/metastore/test/testclasses/my/ParentElement.java
+++ b/test-src/org/pentaho/metastore/test/testclasses/my/ParentElement.java
@@ -1,0 +1,33 @@
+package org.pentaho.metastore.test.testclasses.my;
+
+
+import org.pentaho.metastore.persist.MetaStoreAttribute;
+import org.pentaho.metastore.persist.MetaStoreElementType;
+
+@MetaStoreElementType(
+  name = "ParentElement",
+  description = "ParentElement" )
+public class ParentElement {
+
+  @MetaStoreAttribute
+  private String name;
+
+  @MetaStoreAttribute
+  private ChildElement childElement;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName( String name ) {
+    this.name = name;
+  }
+
+  public ChildElement getChildElement() {
+    return childElement;
+  }
+
+  public void setChildElement( ChildElement childElement ) {
+    this.childElement = childElement;
+  }
+}


### PR DESCRIPTION
Adding unit tests based on the 5.4 codebase. I will then cherry-pick this into master (the unit tests there should break due to the changes in the MetastoreFactory). This will provide a good way to pin point what needs to be fixed in the source (not the test) to ensure backwards compatibility.