### PR TITLE
[BACKLOG-4445] - adding a utility method to copy (convert) one metast…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist
 /test-lib
 /lib
+*.iml

--- a/src/org/pentaho/metastore/stores/xml/XmlMetaStore.java
+++ b/src/org/pentaho/metastore/stores/xml/XmlMetaStore.java
@@ -256,7 +256,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
         elementType.setId( elementType.getName() );
       }
 
-      String elementTypeFolder = XmlUtil.getElementTypeFolder( rootFolder, namespace, elementType.getId() );
+      String elementTypeFolder = XmlUtil.getElementTypeFolder( rootFolder, namespace, elementType.getName() );
       File elementTypeFolderFile = new File( elementTypeFolder );
       if ( elementTypeFolderFile.exists() ) {
         throw new MetaStoreElementTypeExistsException( getElementTypes( namespace, false ),
@@ -266,7 +266,7 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
         throw new MetaStoreException( "Unable to create XML meta store element type folder '" + elementTypeFolder + "'" );
       }
 
-      String elementTypeFilename = XmlUtil.getElementTypeFile( rootFolder, namespace, elementType.getId() );
+      String elementTypeFilename = XmlUtil.getElementTypeFile( rootFolder, namespace, elementType.getName() );
 
       // Copy the element type information to the XML meta store
       //
@@ -291,14 +291,14 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
     throws MetaStoreException {
     lockStore();
     try {
-      String elementTypeFolder = XmlUtil.getElementTypeFolder( rootFolder, namespace, elementType.getId() );
+      String elementTypeFolder = XmlUtil.getElementTypeFolder( rootFolder, namespace, elementType.getName() );
       File elementTypeFolderFile = new File( elementTypeFolder );
       if ( !elementTypeFolderFile.exists() ) {
         throw new MetaStoreException( "The specified element type with ID '" + elementType.getId()
             + "' doesn't exists so we can't update it." );
       }
 
-      String elementTypeFilename = XmlUtil.getElementTypeFile( rootFolder, namespace, elementType.getId() );
+      String elementTypeFilename = XmlUtil.getElementTypeFile( rootFolder, namespace, elementType.getName() );
 
       // Save the element type information to the XML meta store
       //

--- a/src/org/pentaho/metastore/util/MetaStoreUtil.java
+++ b/src/org/pentaho/metastore/util/MetaStoreUtil.java
@@ -27,7 +27,10 @@ import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.api.IMetaStoreAttribute;
 import org.pentaho.metastore.api.IMetaStoreElement;
 import org.pentaho.metastore.api.IMetaStoreElementType;
+import org.pentaho.metastore.api.exceptions.MetaStoreElementExistException;
+import org.pentaho.metastore.api.exceptions.MetaStoreElementTypeExistsException;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.api.exceptions.MetaStoreNamespaceExistsException;
 
 /**
  * Generally useful methods for extracting data
@@ -124,5 +127,40 @@ public class MetaStoreUtil {
     Collections.sort( names );
 
     return names.toArray( new String[names.size()] );
+  }
+
+  public static void copy( IMetaStore from, IMetaStore to ) throws MetaStoreException {
+
+    // get all of the namespace in the "from" metastore
+    List<String> namespaces = from.getNamespaces();
+    for ( String namespace : namespaces ) {
+      // create the sme namespace in the "to" metastore
+      try {
+        to.createNamespace( namespace );
+      } catch ( MetaStoreNamespaceExistsException e ) {
+        // already there
+      }
+      // get all of the element types defined in this namespace
+      List<IMetaStoreElementType> elementTypes = from.getElementTypes( namespace );
+      for ( IMetaStoreElementType elementType : elementTypes ) {
+        // create the elementType in the "to" metastore
+        try {
+          to.createElementType( namespace, elementType );
+        } catch ( MetaStoreElementTypeExistsException e ) {
+          // already there
+        }
+        // get all of the elements defined for this type
+        List<IMetaStoreElement> elements = from.getElements( namespace, elementType );
+        for ( IMetaStoreElement element : elements ) {
+          // create the element in the "to" metastore
+          try {
+            to.createElement( namespace, elementType, element );
+          } catch ( MetaStoreElementExistException e ) {
+            // already there
+          }
+        }
+      }
+    }
+
   }
 }

--- a/test-src/org/pentaho/metastore/util/MetaStoreUtilTest.java
+++ b/test-src/org/pentaho/metastore/util/MetaStoreUtilTest.java
@@ -1,0 +1,89 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.metastore.util;
+
+import org.junit.Test;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.IMetaStoreElement;
+import org.pentaho.metastore.api.IMetaStoreElementType;
+import org.pentaho.metastore.stores.memory.MemoryMetaStore;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MetaStoreUtilTest {
+
+  @Test
+  public void testCopyElements_empty() throws Exception {
+    IMetaStore from = new MemoryMetaStore();
+    IMetaStore to = new MemoryMetaStore();
+
+    MetaStoreUtil.copy( from, to );
+
+    assertEquals( from.getNamespaces().size(), to.getNamespaces().size() );
+  }
+
+  @Test
+  public void testCopy() throws Exception {
+    IMetaStore from = mock( IMetaStore.class );
+    IMetaStore to = mock( IMetaStore.class );
+
+    String[] namespaces = new String[] { "pentaho", "hitachi" };
+    List<IMetaStoreElementType> penElementTypes = new ArrayList<>();
+    IMetaStoreElementType type1 = mock( IMetaStoreElementType.class );
+    IMetaStoreElementType type2 = mock( IMetaStoreElementType.class );
+    penElementTypes.add( type1 );
+    penElementTypes.add( type2 );
+
+    List<IMetaStoreElement> elements = new ArrayList<>();
+    IMetaStoreElement elem1 = mock( IMetaStoreElement.class );
+    IMetaStoreElement elem2 = mock( IMetaStoreElement.class );
+    IMetaStoreElement elem3 = mock( IMetaStoreElement.class );
+    elements.add( elem1 );
+    elements.add( elem2 );
+    elements.add( elem3 );
+
+    when( from.getNamespaces() ).thenReturn( Arrays.asList( namespaces ) );
+    when( from.getElementTypes( "pentaho" ) ).thenReturn( penElementTypes );
+    when( from.getElements( "pentaho", type1 ) ).thenReturn( elements );
+    when( from.getElements( "pentaho", type2 ) ).thenReturn( elements );
+
+    MetaStoreUtil.copy( from, to );
+
+    verify( to ).createNamespace( "pentaho" );
+    verify( to ).createNamespace( "hitachi" );
+    verify( to ).createElementType( "pentaho", type1 );
+    verify( to ).createElementType( "pentaho", type2 );
+    verify( to ).createElement( "pentaho", type1, elem1 );
+    verify( to ).createElement( "pentaho", type1, elem2 );
+    verify( to ).createElement( "pentaho", type1, elem3 );
+    verify( to ).createElement( "pentaho", type2, elem1 );
+    verify( to ).createElement( "pentaho", type2, elem2 );
+    verify( to ).createElement( "pentaho", type2, elem3 );
+
+    verify( to, never() ).createElementType( eq( "hitachi" ), any( IMetaStoreElementType.class ) );
+    verify( to, never() ).createElement( eq( "hitachi" ), any( IMetaStoreElementType.class ), any( IMetaStoreElement.class ) );
+  }
+
+
+
+}


### PR DESCRIPTION
…ore instance to another to support backup/restore of the metastore as part of a full system backup/restore.

I had to modify the XMLMetaStore slightly to support converting between a repository-based metastore and an xml one. it seems a while back there was a refactor for performance reasons to use element type names rather than id's on the filesystem. However, this wasn't fully completed. Since Id's are not null coming from a repository metastore, the resulting xml metastore file system structure was using the UUID's for the element types. This caused a failure when trying to create a new element for a given element type, it couldn't find the folder it was supposed to put the xml file in since it expected the element type name to be the folder, not it's id.