### PR TITLE
[BACKLOG-28595] Transformation that successfully executes in Spoon is…

### DIFF
--- a/src/main/java/org/pentaho/metastore/stores/delegate/DelegatingMetaStore.java
+++ b/src/main/java/org/pentaho/metastore/stores/delegate/DelegatingMetaStore.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.metastore.stores.delegate;
@@ -95,8 +95,9 @@ public class DelegatingMetaStore implements IMetaStore {
   }
 
   private List<IMetaStore> getReadMetaStoreList() throws MetaStoreException {
-    if ( activeMetaStoreName != null ) {
-      return Arrays.asList( getMetaStore( activeMetaStoreName ) );
+    IMetaStore activeMetaStore;
+    if ( activeMetaStoreName != null && ( activeMetaStore = getMetaStore( activeMetaStoreName ) ) != null ) {
+      return Arrays.asList( activeMetaStore );
     }
     return metaStoreList;
   }

--- a/src/test/java/org/pentaho/metastore/test/DelegatingMetastoreTest.java
+++ b/src/test/java/org/pentaho/metastore/test/DelegatingMetastoreTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.metastore.test;
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -1295,6 +1296,17 @@ public class DelegatingMetastoreTest {
     verify( activeMetaStore ).newElementOwner( mockElementId, ownerType );
     verify( inactiveMetaStore1, never() ).newAttribute( anyString(), any( MetaStoreElementOwnerType.class ) );
     verify( inactiveMetaStore2, never() ).newAttribute( anyString(), any( MetaStoreElementOwnerType.class ) );
+  }
+
+  @Test
+  public void testDelegatingMetaStoreDoesNotHoldListOfNullObjects() throws MetaStoreException {
+    DelegatingMetaStore delegatingMetaStore =
+        new DelegatingMetaStore( mock( IMetaStore.class ), mock( IMetaStore.class ) );
+    try {
+      assertFalse( delegatingMetaStore.namespaceExists( "some-dummy-namespace" ) );
+    } catch ( MetaStoreException me ) {
+      fail();
+    }
   }
 
   private IMetaStore getMockMetaStoreWithName( String name ) throws MetaStoreException {


### PR DESCRIPTION
… unsuccessful when executed from Pan

- The fix made for https://jira.pentaho.com/browse/PDI-18015 fixed the reading of the local metastore, which in turn bubbled up this one ( hidden ) bug:

1. `TransMeta` tries to read some namespace from a local metastore;
2. User's local machine's metastore does not happen to have that one ( which is fine )
  2.1.  i.e. `getMetaStore( activeMetaStoreName )` returns null;
3. The code as-was does `Arrays.asList( getMetaStore( activeMetaStoreName ) )`, which means it will return a list with a size of 1, where the object within the list is null;
4. The method `namespaceExists()` , receiving a list of 1, iterates over it:

```
for ( IMetaStore metaStore : getReadMetaStoreList() ) {
      if ( metaStore.namespaceExists( namespace ) ) {
        return true;
      }
    }
``` 

however, in this scenario, `metaStore` object came as `null`.  Hence the NPE in the logs.


@pentaho/rogueone  
