### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,12 @@
     <guava.version>17.0</guava.version>
     <commons-io.version>2.1</commons-io.version>
     <mockito-all.version>1.8.4</mockito-all.version>
-    <commons-codec.version>1.5</commons-codec.version>
     <junit.version>4.7</junit.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.
Moving dependency management to the parent POMs.

Please see https://github.com/pentaho/maven-parent-poms/pull/214 for details.