### PR TITLE
[SP-6420] - Backport of PDI-19756 - java.lang.NullPointerException with "Write metadata to HCP" step if the number of copies to start is increased (9.3 Suite)

### DIFF
--- a/src/main/java/org/pentaho/metastore/stores/xml/XmlMetaStore.java
+++ b/src/main/java/org/pentaho/metastore/stores/xml/XmlMetaStore.java
@@ -19,6 +19,7 @@ package org.pentaho.metastore.stores.xml;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -682,11 +683,16 @@ public class XmlMetaStore extends BaseMetaStore implements IMetaStore {
     while ( waiting ) {
       File lockFile = new File( rootFile, ".lock" );
       try {
-        if ( lockFile.createNewFile() ) {
+        // PDI-19756: make fewer calls to createNewFile() to prevent random Windows error
+        if ( !lockFile.exists() && lockFile.createNewFile() ) {
           return;
         }
       } catch ( IOException e ) {
-        throw new MetaStoreException( "Unable to create lock file: " + lockFile.toString(), e );
+        // PDI-19756: Due to known issue with createNewFile()
+        // we are trying to understand if the exception is due to lack of permissions or just a random fail
+        if ( e.getMessage().contains( "Access is denied" ) && Files.isWritable( Paths.get( rootFile.getPath() ) ) ) {
+          continue;
+        }
       }
       try {
         Thread.sleep( 100 );


### PR DESCRIPTION
Original PR:
 - https://github.com/pentaho/metastore/pull/86